### PR TITLE
Support for loading OPENCV_FISHEYE camera parameters

### DIFF
--- a/pycolmap/camera.py
+++ b/pycolmap/camera.py
@@ -48,8 +48,8 @@ class Camera:
             return 5
         if type_ == 4 or type_ == 'OPENCV':
             return 8
-        #if type_ == 5 or type_ == 'OPENCV_FISHEYE':
-        #    return 8
+        if type_ == 5 or type_ == 'OPENCV_FISHEYE':
+           return 8
         #if type_ == 6 or type_ == 'FULL_OPENCV':
         #    return 12
         #if type_ == 7 or type_ == 'FOV':
@@ -74,7 +74,7 @@ class Camera:
         if type_ == 2: return 'SIMPLE_RADIAL'
         if type_ == 3: return 'RADIAL'
         if type_ == 4: return 'OPENCV'
-        #if type_ == 5: return 'OPENCV_FISHEYE'
+        if type_ == 5: return 'OPENCV_FISHEYE'
         #if type_ == 6: return 'FULL_OPENCV'
         #if type_ == 7: return 'FOV'
         #if type_ == 8: return 'SIMPLE_RADIAL_FISHEYE'
@@ -119,6 +119,14 @@ class Camera:
             self.distortion_func = opencv_distortion
             self.camera_type = 4
 
+        elif type_ == 5 or type_ == 'OPENCV_FISHEYE':
+            self.fx, self.fy, self.cx, self.cy = params[:4]
+            self.k1, self.k2, self.k3, self.k4 = params[4:]
+            def error_fn(camera, x):
+                raise Exception('Fisheye distortion not supported')
+            self.distortion_func = error_fn
+            self.camera_type = 5
+
         else:
             raise Exception('Camera type not supported')
 
@@ -143,6 +151,9 @@ class Camera:
         elif self.camera_type == 4: # OPENCV
             s += ' {} {} {} {}'.format(self.k1, self.k2, self.p1, self.p2)
 
+        elif self.camera_type == 5:  # OPENCV_FISHEYE
+            s += ' {} {} {} {}'.format(self.k1, self.k2, self.k3, self.k4)
+
         return s
 
 
@@ -161,7 +172,9 @@ class Camera:
         if self.camera_type == 4:
             return np.array((self.fx, self.fy, self.cx, self.cy, self.k1,
                              self.k2, self.p1, self.p2))
-
+        if self.camera_type == 5:
+           return np.array((self.fx, self.fy, self.cx, self.cy, self.k1, self.k2,
+                            self.k3, self.k4))
 
     #---------------------------------------------------------------------------
 


### PR DESCRIPTION
Adding fisheye support for use in [MultiNeRF](https://github.com/google-research/multinerf). Tested with an OPENCV_FISHEYE calibrated dataset on command line.